### PR TITLE
Punkt sentence tokenizer: support roman numerals

### DIFF
--- a/preprocessor/punkt_tokenizer.py
+++ b/preprocessor/punkt_tokenizer.py
@@ -306,7 +306,7 @@ class PunktToken(object):
     #////////////////////////////////////////////////////////////
     # Note: [A-Za-z] is approximated by [^\W\d] in the general case.
     _RE_ELLIPSIS = re.compile(r'\.\.+$')
-    _RE_NUMERIC = re.compile(r'^-?[\.,]?\d[\d,\.-]*\.?$')
+    _RE_NUMERIC = re.compile(r'^-?[\.,]?[\divxlcdm][\d,\.-ivxlcdm]*\.?$')
     _RE_INITIAL = re.compile(r'[^\W\d]\.$', re.UNICODE)
     _RE_ALPHA = re.compile(r'[^\W\d]+$', re.UNICODE)
 


### PR DESCRIPTION
roman numerals are not taken in consideration in the regex for numerals.
roman numerals consist of I, V, X, L, C, D and M and may also followed by a dot in some cases of ordinal usage.
see:
- https://en.wikipedia.org/wiki/Roman_numerals
- [https://de.wikipedia.org/wiki/Benedikt_XVI.](https://de.wikipedia.org/wiki/Benedikt_XVI.)

prior to this patch, an ordinal romanian number occurence with a dot always leads to a sentence ending:
```python
tokenizer.sentences_from_text('Benedikt XVI. ist emeritierter Papst.')
# returns ['Benedikt XVI.', 'ist emeritierter Papst.']
next(tokenizer.debug_decisions('Benedikt XVI. ist emeritierter Papst.'))
# returns
{'period_index': 12,
 'text': 'XVI. ist',
 'type1': 'xvi.',
 'type2': 'ist',
 'type1_in_abbrs': False,
 'type1_is_initial': False,
 'type2_is_sent_starter': False,
 'type2_ortho_heuristic': False,
 'type2_ortho_contexts': {'BEG-UC', 'MID-LC', 'MID-UC', 'UNK-LC', 'UNK-UC'},
 'collocation': False,
 'reason': 'default decision',
 'break_decision': True}
```

after application of this patch, the case is properly handled:
```python
tokenizer.sentences_from_text('Benedikt XVI. ist emeritierter Papst.')
# returns ['Benedikt XVI. ist emeritierter Papst.']
next(tokenizer.debug_decisions('Benedikt XVI. ist emeritierter Papst.'))
# returns:
{'period_index': 12,
 'text': 'XVI. ist',
 'type1': '##number##',
 'type2': 'ist',
 'type1_in_abbrs': False,
 'type1_is_initial': False,
 'type2_is_sent_starter': False,
 'type2_ortho_heuristic': False,
 'type2_ortho_contexts': {'BEG-UC', 'MID-LC', 'MID-UC', 'UNK-LC', 'UNK-UC'},
 'collocation': False,
 'reason': 'initial + orthographic heuristic',
 'break_decision': False}
```