### PR TITLE
continuous server fixes

### DIFF
--- a/parzu_class.py
+++ b/parzu_class.py
@@ -252,7 +252,7 @@ class Parser():
                                                ['-q', '-s', os.path.join(root_directory,'preprocessor','preprocessing.pl')],
                                                echo=False,
                                                encoding='utf-8',
-                                               timeout=2)
+                                               timeout=5)
 
         self.prolog_preprocess.expect_exact('?- ')
         self.prolog_preprocess.delaybeforesend = 0
@@ -263,7 +263,7 @@ class Parser():
                                            echo=False,
                                            encoding='utf-8',
                                            cwd=os.path.join(root_directory,'core'),
-                                           timeout=2)
+                                           timeout=5)
 
         self.prolog_parser.expect_exact('?- ')
         self.prolog_parser.delaybeforesend = 0

--- a/parzu_class.py
+++ b/parzu_class.py
@@ -252,7 +252,7 @@ class Parser():
                                                ['-q', '-s', os.path.join(root_directory,'preprocessor','preprocessing.pl')],
                                                echo=False,
                                                encoding='utf-8',
-                                               timeout=5)
+                                               timeout=10)
 
         self.prolog_preprocess.expect_exact('?- ')
         self.prolog_preprocess.delaybeforesend = 0
@@ -263,7 +263,7 @@ class Parser():
                                            echo=False,
                                            encoding='utf-8',
                                            cwd=os.path.join(root_directory,'core'),
-                                           timeout=5)
+                                           timeout=10)
 
         self.prolog_parser.expect_exact('?- ')
         self.prolog_parser.delaybeforesend = 0


### PR DESCRIPTION
When using in Python, the loaded class would parse on the first call but hang forever on the second call. Not sure why. `.readline()` on the pexpect.spawn object returns 'true.' on first call but '?- true.' on the second ('?- |  true.' in the main parser response).
Anyway, now it seems to work for multiple calls to the same parser object.