### PR TITLE
Fixed parzu.py Popen call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
     python-is-python3
 
 ADD https://api.github.com/repos/rsennrich/ParZu/git/refs/heads/master version.json
-RUN git clone https://github.com/rsennrich/ParZu
+RUN git clone https://github.com/WilyWildWilly/ParZu.git
 
 RUN (cd ParZu; bash install.sh)
 

--- a/parzu.py
+++ b/parzu.py
@@ -49,7 +49,7 @@ if '__file__' in globals():
 
 # get swi-prolog version
 if prolog == 'swipl':
-    swipl_version, _ = Popen(['swipl', '--version'], stdout=PIPE, text=True).communicate()
+    swipl_version, _ = Popen(['swipl', '--version'], stdout=PIPE, universal_newlines=True).communicate()
     swipl_version = swipl_version.split()
     try:
         swipl_version = list(map(int,swipl_version[swipl_version.index('version')+1].split('.')))


### PR DESCRIPTION
Hello Rico,

Ignore the change in the Dockerfile (which pulls my fork instead of this repo) - the fix on line 52 (argument "universal_newline" instead of "text") seems to solve the only problem we were having in running it.
If you merge it then we can run ParZu again.


Best,
Guglielmo